### PR TITLE
Improve create_workarea.sh

### DIFF
--- a/docker/create_workarea.sh
+++ b/docker/create_workarea.sh
@@ -1,30 +1,44 @@
-DUNEDAQ_RELEASE=$1
-if [[ "$DUNEDAQ_RELEASE" =~ ^(fd|nd)daq-v4.1.0 ]]; then
-    DBT_CREATE_OPTS=""
-    DBT_VERSION=$DUNEDAQ_RELEASE
-elif [[ "$DUNEDAQ_RELEASE" = "rc-"* ]]; then
-    DBT_CREATE_OPTS="-b candidate"
-    X=${DUNEDAQ_RELEASE/rc-/}
-    DBT_VERSION=dunedaq-${X/-*/}
+#!/bin/bash
+usage() {
+    echo "Usage: $0 <dune|fd|nd>daq-<version>-<a9|c8>"
+    echo "where the <version> format is vX.Y.Z"
+    exit 1
+}
+
+if [ "$#" -ne 1 ]; then
+    echo "You must provide a release name as a single argument"
+    usage
 fi
 
-echo "------------------------------------------"
-echo "Setting up spack python"
-echo "------------------------------------------"
-source /cvmfs/dunedaq.opensciencegrid.org/spack/externals/stable/spack-0.18.1-gcc-12.1.0/spack-installation/share/spack/setup-env.sh
-spack load python@3.10.4
+DUNEDAQ_RELEASE=$1
+#if [[ "$DUNEDAQ_RELEASE" =~ ^(fd|nd)daq-v4.3.0-a9 ]]; then
+#    DBT_CREATE_OPTS=""
+#    DBT_VERSION=$DUNEDAQ_RELEASE
+if [[ "$DUNEDAQ_RELEASE" = *"rc-"* ]]; then
+    DBT_CREATE_OPTS="-b candidate"
+fi
+
+# Parse necessary dbt version from the release symbolic link
+DBT_DIR=/cvmfs/dunedaq.opensciencegrid.org/tools/dbt/
+if [ -e ${DBT_DIR}/$1 ]; then
+    DBT_VERSION=$(readlink -f ${DBT_DIR}/$1 | rev | cut -d'/' -f1 | rev)
+    echo "DBT version for $RELEASE: $DBT_VERSION"
+else
+    echo "Error: Symbolic link not found for $1 in $DBT_DIR."
+    exit 1
+fi
 
 source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-
 echo "------------------------------------------"
 echo "Loading daq-buildtool environment"
 echo "------------------------------------------"
+echo "DBT version: $DBT_VERSION"
 setup_dbt ${DBT_VERSION}
 
 echo "------------------------------------------"
 echo "Loading daq-release workarea"
 echo "------------------------------------------"
-dbt-create -c ${DBT_CREATE_OPTS} ${DUNEDAQ_RELEASE} dunedaq-area
+dbt-create ${DBT_CREATE_OPTS} ${DUNEDAQ_RELEASE} dunedaq-area
 
 cd dunedaq-area
 source ./env.sh

--- a/docker/create_workarea.sh
+++ b/docker/create_workarea.sh
@@ -2,6 +2,7 @@
 usage() {
     echo "Usage: $0 <dune|fd|nd>daq-<version>-<a9|c8>"
     echo "where the <version> format is vX.Y.Z"
+    echo "For a candidate release, the format is <dune|fd|nd>daq-<version>-rc<iteration>-<a9|c8>"
     exit 1
 }
 
@@ -11,20 +12,20 @@ if [ "$#" -ne 1 ]; then
 fi
 
 DUNEDAQ_RELEASE=$1
-#if [[ "$DUNEDAQ_RELEASE" =~ ^(fd|nd)daq-v4.3.0-a9 ]]; then
-#    DBT_CREATE_OPTS=""
-#    DBT_VERSION=$DUNEDAQ_RELEASE
+# "rc" denotes a candidate release, as opposed to frozen
 if [[ "$DUNEDAQ_RELEASE" = *"rc-"* ]]; then
     DBT_CREATE_OPTS="-b candidate"
 fi
 
 # Parse necessary dbt version from the release symbolic link
 DBT_DIR=/cvmfs/dunedaq.opensciencegrid.org/tools/dbt/
-if [ -e ${DBT_DIR}/$1 ]; then
-    DBT_VERSION=$(readlink -f ${DBT_DIR}/$1 | rev | cut -d'/' -f1 | rev)
+DBT_RELEASE=$(echo $DUNEDAQ_RELEASE | cut -d'-' -f1-2)
+if [ -e ${DBT_DIR}/$DBT_RELEASE ]; then
+    DBT_VERSION=$(readlink -f ${DBT_DIR}/$DBT_RELEASE | rev | cut -d'/' -f1 | rev)
     echo "DBT version for $RELEASE: $DBT_VERSION"
 else
-    echo "Error: Symbolic link not found for $1 in $DBT_DIR."
+    echo "Error: Symbolic link not found for $DBT_RELEASE in $DBT_DIR."
+    usage
     exit 1
 fi
 
@@ -38,6 +39,7 @@ setup_dbt ${DBT_VERSION}
 echo "------------------------------------------"
 echo "Loading daq-release workarea"
 echo "------------------------------------------"
+set -e # If this next step errors, stop the script
 dbt-create ${DBT_CREATE_OPTS} ${DUNEDAQ_RELEASE} dunedaq-area
 
 cd dunedaq-area


### PR DESCRIPTION
In its current form, `create_workarea.sh` will not work for a general user. There are hard-coded versions and paths that cause the script to fail. This PR aims to make this script more portable, user-friendly, and future-proof by
- Adding usage instructions
- Updating the expected dbt path on /cvmfs 
- Inferring the necessary dbt version from the provided release name
- Removing the manual setup of the spack environment (setup_dbt does this)
- Modernizing the logic for release candidate names (the naming convention changed recently)
- Checking if a release exists and complaining loudly if not

There may still be a smarter way to handle the /cvmfs path finding, but I think this is still an improvement for now.