### PR TITLE
Add functionality for automatically refreshing plots with new data files

### DIFF
--- a/src/justintime/app.py
+++ b/src/justintime/app.py
@@ -49,6 +49,12 @@ def init_dashboard(dash_app, raw_data_path, channel_map_id,template):
     layout = []
     layout.append(create_navbar(pages))
 
+    interval_time_seconds = 30
+    interval = dcc.Interval(
+        id="refresh_interval", interval=interval_time_seconds*1000, n_intervals=0
+    )
+    layout.append(interval)
+
     layout.append(html.Div(
     children=[
         html.Div(

--- a/src/justintime/app.py
+++ b/src/justintime/app.py
@@ -99,8 +99,8 @@ def init_dashboard(dash_app, raw_data_path, channel_map_id,template):
                                 
                             ],
                         ),
-                        html.Div([plot.div for plot in plots], id = "plots_div",style={'fontSize': '14px '})],
-                
+                        html.Div([plot.div for plot in plots], id = "plots_div",style={'fontSize': '14px '})
+                    ],
                 ),
             
     ],style={"backgroundColor":["#f6f3f3e4" if template=="flatly" else "#222"]})]
@@ -112,7 +112,7 @@ def init_dashboard(dash_app, raw_data_path, channel_map_id,template):
 
     dash_app.layout = html.Div(layout)
 
-def init_page_callback(dash_app, storge):
+def init_page_callback(dash_app, storage):
     pages, plots, ctrls = ld.get_elements()
     
     page_output=[Output("text_page","children")]
@@ -144,7 +144,7 @@ def init_page_callback(dash_app, storge):
                 
                 if f"/{page.id}" in pathname or pathname=="/":
                     page_output=page.name
-                    return(calculate_page_style_list(page, plots, ctrls, style_list, storge))
+                    return(calculate_page_style_list(page, plots, ctrls, style_list, storage))
                     
         return(style_list)    
 
@@ -161,7 +161,7 @@ def init_page_callback(dash_app, storge):
                     
                     return([page.text])
           
-def calculate_page_style_list(page, plots, ctrls, style_list, storge):
+def calculate_page_style_list(page, plots, ctrls, style_list, storage):
     needed_plots = []
     needed_ctrls = []
     for plot_n, plot in enumerate(plots):
@@ -171,7 +171,7 @@ def calculate_page_style_list(page, plots, ctrls, style_list, storge):
             for ctrl in ctrls:
                 if (ctrl.id in plot.ctrls) and not (ctrl.id in needed_ctrls):
                     needed_ctrls.append(ctrl.id)
-    storge.update_shown_plots(needed_plots)
+    storage.update_shown_plots(needed_plots)
     needed_ctrls = get_ctrl_dependancies(ctrls,needed_ctrls)
 
     for ctrl_n, ctrl in enumerate(ctrls):

--- a/src/justintime/controls/content/04_partition_run_select_ctrl.py
+++ b/src/justintime/controls/content/04_partition_run_select_ctrl.py
@@ -52,7 +52,7 @@ def init_callbacks(dash_app, engine):
         if not data:
             return {}
         opts = list(data.keys())
-        return (opts, None)
+        return (opts, opts[0])
 
 
     @dash_app.callback(
@@ -70,14 +70,18 @@ def init_callbacks(dash_app, engine):
     
     @dash_app.callback(
         Output('run_select_ctrl', 'options'),
+        Output('run_select_ctrl', 'value'),
         Input('partition_storage_id', 'data')
         )
     def update_select(stored_value):
         logging.debug('update_run_selection called')
         if not stored_value:
-            return []
-        options = [{'label':str(n), 'value':str(n)} for n in sorted(stored_value, reverse=True)]
-        return(options)
+            return [], None
+        #options = [{'label':str(n), 'value':str(n)} for n in sorted(stored_value, reverse=True)]
+        options = [{'label':str(n), 'value':str(n)} for n in stored_value]
+        latest_run_number = max(options, key=lambda x: int(x['label']))['label']
+        #return(options, str(latest_run_number))
+        return(options, latest_run_number)
         
 
     @dash_app.callback(

--- a/src/justintime/controls/content/04_partition_run_select_ctrl.py
+++ b/src/justintime/controls/content/04_partition_run_select_ctrl.py
@@ -71,16 +71,15 @@ def init_callbacks(dash_app, engine):
     @dash_app.callback(
         Output('run_select_ctrl', 'options'),
         Output('run_select_ctrl', 'value'),
-        Input('partition_storage_id', 'data')
+        Input('partition_storage_id', 'data'),
+        State('run_select_ctrl', 'value')
         )
-    def update_select(stored_value):
+    def update_select(stored_value, stored_run_value):
         logging.debug('update_run_selection called')
         if not stored_value:
             return [], None
-        #options = [{'label':str(n), 'value':str(n)} for n in sorted(stored_value, reverse=True)]
         options = [{'label':str(n), 'value':str(n)} for n in stored_value]
         latest_run_number = max(options, key=lambda x: int(x['label']))['label']
-        #return(options, str(latest_run_number))
         return(options, latest_run_number)
         
 

--- a/src/justintime/controls/content/05_file_select_ctrl.py
+++ b/src/justintime/controls/content/05_file_select_ctrl.py
@@ -31,10 +31,11 @@ def init_callbacks(dash_app, engine):
     @dash_app.callback(
         Output('file_select_ctrl', 'options'),
         Output('file_select_ctrl', 'value'),
-        Input('run_storage_id', 'data')
+        Input('run_storage_id', 'data'),
+        State('file_select_ctrl', 'value')
         )
     
-    def update_select(stored_value):
+    def update_select(stored_value, stored_file_value):
 
         if not stored_value:
             return []

--- a/src/justintime/controls/content/05_file_select_ctrl.py
+++ b/src/justintime/controls/content/05_file_select_ctrl.py
@@ -30,6 +30,7 @@ def init_callbacks(dash_app, engine):
 
     @dash_app.callback(
         Output('file_select_ctrl', 'options'),
+        Output('file_select_ctrl', 'value'),
         Input('run_storage_id', 'data')
         )
     
@@ -38,7 +39,7 @@ def init_callbacks(dash_app, engine):
         if not stored_value:
             return []
         options = [{'label':str(n), 'value':str(n)} for n in stored_value]
-        return(options)
+        return(options, options[0]['label'])
         
     @dash_app.callback(
         Output('file_storage_id', 'data'),

--- a/src/justintime/controls/content/06_trigger_record_select_ctrl.py
+++ b/src/justintime/controls/content/06_trigger_record_select_ctrl.py
@@ -27,10 +27,11 @@ def init_callbacks(dash_app, engine):
     @dash_app.callback(
         Output('trigger_record_select_ctrl', 'options'),
         Output('trigger_record_select_ctrl', 'value'),
-        Input('file_storage_id', 'data')
+        Input('file_storage_id', 'data'),
+        State('trigger_record_select_ctrl', 'value')
         )
     
-    def update_trigger_record_select(raw_data_file):
+    def update_trigger_record_select(raw_data_file, stored_trigger_record):
         if not raw_data_file:
             return []
         tr_nums = [{'label':str(n), 'value':str(n)} for n in engine.get_trigger_record_list(raw_data_file)]

--- a/src/justintime/controls/content/06_trigger_record_select_ctrl.py
+++ b/src/justintime/controls/content/06_trigger_record_select_ctrl.py
@@ -26,6 +26,7 @@ def init_callbacks(dash_app, engine):
 
     @dash_app.callback(
         Output('trigger_record_select_ctrl', 'options'),
+        Output('trigger_record_select_ctrl', 'value'),
         Input('file_storage_id', 'data')
         )
     
@@ -33,4 +34,5 @@ def init_callbacks(dash_app, engine):
         if not raw_data_file:
             return []
         tr_nums = [{'label':str(n), 'value':str(n)} for n in engine.get_trigger_record_list(raw_data_file)]
-        return(tr_nums)
+        latest_trigger_number = max(tr_nums, key=lambda x: int(x['label']))['label']
+        return(tr_nums, str(latest_trigger_number))

--- a/src/justintime/controls/content/07_refresh_ctrl.py
+++ b/src/justintime/controls/content/07_refresh_ctrl.py
@@ -1,24 +1,50 @@
-from dash import html, dcc
+from dash import html, dcc, callback_context
 from dash.dependencies import Input, Output, State
 import logging
+from datetime import datetime
 from .. import ctrl_class
 
 def return_obj(dash_app, engine, storage):
     ctrl_id = "07_refresh_ctrl"
-   
-    ctrl_div = html.Div([html.Button('Refresh Files', id=ctrl_id, n_clicks=0)],style={"marginBottom":"1.0em"})
-    ctrl = ctrl_class.ctrl("refresh_button", ctrl_id, ctrl_div, engine)
+    last_refresh_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    ctrl_div = html.Div([
+        html.Button('Refresh Files', id=ctrl_id, n_clicks=0),
+        html.Div(
+            dcc.Checklist(
+                options=[{'label': 'Automatic Refresh', 'value': 'auto_refresh'}],
+                value=['auto_refresh'],
+                id='07_auto_refresh'
+            ),
+            style={"marginTop": "1.0em", "fontSize": "1.5rem"}
+        ),
+        html.Div(f"This page was last refreshed at {last_refresh_time}", id="last_refresh_time")
+    ], style={"marginBottom": "1.0em"})  # Add margin to the bottom of the whole control
     
+    ctrl = ctrl_class.ctrl("refresh_button", ctrl_id, ctrl_div, engine)
     init_callbacks(dash_app, engine)
 
     return(ctrl)
     
 def init_callbacks(dash_app, engine):
     @dash_app.callback(
-        Output('session_run_files_map', 'data'),
-        Input('07_refresh_ctrl', 'n_clicks')
+        [Output('session_run_files_map', 'data'),
+        Output('last_refresh_time', 'children')],
+        [Input('07_refresh_ctrl', 'n_clicks'),
+        Input('refresh_interval', 'n_intervals')],
+        [State('07_auto_refresh', 'value')]
         )
-    def update_file_list(n_clicks):  
-        logging.debug('update files clicked!')
+    def update_file_list(n_clicks, refresh_interval, auto_refresh):  
+        data = []
+        triggered_id = callback_context.triggered[0]['prop_id']
+        last_refresh_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         data=engine.get_session_run_files_map()
-        return (data)
+        # Initial page load or when "Refresh" is clicked
+        if triggered_id == '.' or triggered_id == '07_refresh_ctrl.n_clicks':
+            logging.debug('update files clicked!')
+            if not data:
+                logging.error('[07_refresh_ctrl] No session files found')
+        # Automatic interval refresh
+        elif triggered_id == 'refresh_interval.n_intervals' and auto_refresh:
+            logging.info(f'Automatic refresh triggered at {last_refresh_time}')
+        last_refresh_message = f'This page was last refreshed at {last_refresh_time}'
+        return data if 'auto_refresh' in auto_refresh else dash.no_update, last_refresh_message

--- a/src/justintime/controls/content/08_adc_map_selection_ctrl.py
+++ b/src/justintime/controls/content/08_adc_map_selection_ctrl.py
@@ -18,7 +18,7 @@ def return_obj(dash_app, engine, storage):
                 {'label': 'V', 'value': 'V'},
                 {'label': 'U', 'value': 'U'},
             ],
-            value=[],
+            value=['Z', 'U', 'V'],
             labelStyle={'display': 'inline-block',"marginRight":"0.2em"},
             style={'display': 'inline-block',"marginRight":"0.2em"},
         )

--- a/src/justintime/controls/content/90_plot_button_ctrl.py
+++ b/src/justintime/controls/content/90_plot_button_ctrl.py
@@ -17,16 +17,17 @@ def return_obj(dash_app, engine, storage):
 
     ctrl = ctrl_class.ctrl("plot_button", ctrl_id, ctrl_div, engine)
 
-    init_callbacks(dash_app, engine, storage)
+    #init_callbacks(dash_app, engine, storage)
 
     return(ctrl)
 
 # Thought: something with using storage to get the stored trigger record and plot from there?
-def init_callbacks(dash_app, engine, storage):
-    @dash_app.callback(
-        Output('plots_div', 'children'),
-        Input('90_plot_button_ctrl', 'n_clicks')
-        )
-    def update_plots(n_clicks):  
-        logging.debug('Plot button clicked!')
-        return 'Hi'
+#def init_callbacks(dash_app, engine, storage):
+#    @dash_app.callback(
+#        Output('plots_div', 'children'),
+#        Output("90_plot_button_ctrl", "n_clicks"),
+#        Input('90_plot_button_ctrl', 'n_clicks')
+#        )
+#    def update_plots(n_clicks):  
+#        logging.debug('Plot button clicked!')
+#        return 'Hi'

--- a/src/justintime/controls/content/90_plot_button_ctrl.py
+++ b/src/justintime/controls/content/90_plot_button_ctrl.py
@@ -1,5 +1,6 @@
 from dash import html, dcc
 from dash.dependencies import Input, Output, State
+import logging
 
 from .. import ctrl_class
 
@@ -16,5 +17,16 @@ def return_obj(dash_app, engine, storage):
 
     ctrl = ctrl_class.ctrl("plot_button", ctrl_id, ctrl_div, engine)
 
+    init_callbacks(dash_app, engine, storage)
+
     return(ctrl)
 
+# Thought: something with using storage to get the stored trigger record and plot from there?
+def init_callbacks(dash_app, engine, storage):
+    @dash_app.callback(
+        Output('plots_div', 'children'),
+        Input('90_plot_button_ctrl', 'n_clicks')
+        )
+    def update_plots(n_clicks):  
+        logging.debug('Plot button clicked!')
+        return 'Hi'

--- a/src/justintime/controls/content/90_plot_button_ctrl.py
+++ b/src/justintime/controls/content/90_plot_button_ctrl.py
@@ -17,17 +17,5 @@ def return_obj(dash_app, engine, storage):
 
     ctrl = ctrl_class.ctrl("plot_button", ctrl_id, ctrl_div, engine)
 
-    #init_callbacks(dash_app, engine, storage)
-
     return(ctrl)
 
-# Thought: something with using storage to get the stored trigger record and plot from there?
-#def init_callbacks(dash_app, engine, storage):
-#    @dash_app.callback(
-#        Output('plots_div', 'children'),
-#        Output("90_plot_button_ctrl", "n_clicks"),
-#        Input('90_plot_button_ctrl', 'n_clicks')
-#        )
-#    def update_plots(n_clicks):  
-#        logging.debug('Plot button clicked!')
-#        return 'Hi'

--- a/src/justintime/plots/content/01_home_plot.py
+++ b/src/justintime/plots/content/01_home_plot.py
@@ -36,7 +36,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         Input("90_plot_button_ctrl", "n_clicks"),
         Input('01_home_plot', 'style'),
         State('07_refresh_ctrl', "value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
         State('file_select_ctrl', "value"),

--- a/src/justintime/plots/content/01_home_plot.py
+++ b/src/justintime/plots/content/01_home_plot.py
@@ -34,6 +34,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('01_home_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
@@ -42,7 +43,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
      
         State(plot_id, "children")
     )
-    def plot_home_info(n_clicks,refresh, trigger_record,partition,run,raw_data_file ,original_state):
+    def plot_home_info(n_clicks, plot_style, refresh, trigger_record, partition, run, raw_data_file, original_state):
 
         load_figure_template(theme)
 

--- a/src/justintime/plots/content/02_tp_display_plot.py
+++ b/src/justintime/plots/content/02_tp_display_plot.py
@@ -41,7 +41,7 @@ def init_callbacks(dash_app, storage, plot_id, engine,theme):
         Input('02_tp_display_plot', 'style'),
         
         State('07_refresh_ctrl', "value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
         State('file_select_ctrl', "value"),

--- a/src/justintime/plots/content/02_tp_display_plot.py
+++ b/src/justintime/plots/content/02_tp_display_plot.py
@@ -38,6 +38,7 @@ def init_callbacks(dash_app, storage, plot_id, engine,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('02_tp_display_plot', 'style'),
         
         State('07_refresh_ctrl', "value"),
         State('trigger_record_select_ctrl', "value"),
@@ -52,7 +53,7 @@ def init_callbacks(dash_app, storage, plot_id, engine,theme):
         State('02_description_ctrl',"style"),
         State(plot_id, "children"),
     )
-    def plot_tp_graph(n_clicks, refresh, trigger_record, partition, run, raw_data_file,adcmap, tr_color_range, density, orientation, height, description,original_state):
+    def plot_tp_graph(n_clicks, plot_style, refresh, trigger_record, partition, run, raw_data_file, adcmap, tr_color_range, density, orientation, height, description, original_state):
         load_figure_template(theme)
         if trigger_record and raw_data_file:
             if plot_id in storage.shown_plots:

--- a/src/justintime/plots/content/04_mean_plot.py
+++ b/src/justintime/plots/content/04_mean_plot.py
@@ -34,7 +34,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         Input("90_plot_button_ctrl", "n_clicks"),
         Input('04_mean_plot', 'style'),
         State('07_refresh_ctrl', "value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
         State('file_select_ctrl', "value"),

--- a/src/justintime/plots/content/04_mean_plot.py
+++ b/src/justintime/plots/content/04_mean_plot.py
@@ -32,6 +32,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('04_mean_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
@@ -40,7 +41,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State("21_tp_multiplicity_ctrl","value"),
         State(plot_id, "children")
     )
-    def plot_mean_graph(n_clicks,refresh, trigger_record,partition,run,raw_data_file, tps ,original_state):
+    def plot_mean_graph(n_clicks, plot_style, refresh, trigger_record, partition, run, raw_data_file, tps, original_state):
 
         load_figure_template(theme)
         if trigger_record and raw_data_file:

--- a/src/justintime/plots/content/05_std_plot.py
+++ b/src/justintime/plots/content/05_std_plot.py
@@ -32,6 +32,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('05_std_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
@@ -40,7 +41,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State("21_tp_multiplicity_ctrl","value"),
         State(plot_id, "children")
     )
-    def plot_std_graph(n_clicks,refresh, partition,run,trigger_record, raw_data_file, tps,original_state):
+    def plot_std_graph(n_clicks, plot_style, refresh, partition,run, trigger_record, raw_data_file, tps, original_state):
 
         load_figure_template(theme)
         if trigger_record and raw_data_file:

--- a/src/justintime/plots/content/05_std_plot.py
+++ b/src/justintime/plots/content/05_std_plot.py
@@ -36,7 +36,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State('07_refresh_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State('file_select_ctrl', "value"),
         State("21_tp_multiplicity_ctrl","value"),
         State(plot_id, "children")

--- a/src/justintime/plots/content/06_fft_plot.py
+++ b/src/justintime/plots/content/06_fft_plot.py
@@ -30,6 +30,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('06_fft_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
@@ -37,7 +38,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State('file_select_ctrl', "value"),
         State(plot_id, "children"),
     )
-    def plot_fft_graph(n_clicks, refresh,partition,run,trigger_record, raw_data_file, original_state):
+    def plot_fft_graph(n_clicks, plot_style, refresh, partition, run, trigger_record, raw_data_file, original_state):
 
         load_figure_template(theme)
         if trigger_record and raw_data_file:

--- a/src/justintime/plots/content/06_fft_plot.py
+++ b/src/justintime/plots/content/06_fft_plot.py
@@ -34,7 +34,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State('07_refresh_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State('file_select_ctrl', "value"),
         State(plot_id, "children"),
     )

--- a/src/justintime/plots/content/07_fft_phase_plot.py
+++ b/src/justintime/plots/content/07_fft_phase_plot.py
@@ -31,6 +31,7 @@ def init_callbacks(dash_app, storage, plot_id, engine,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('07_fft_phase_plot', 'style'),
         State('07_refresh_ctrl', "n_clicks"),
         State('trigger_record_select_ctrl', "value"),
         State('file_select_ctrl', "value"),
@@ -40,7 +41,7 @@ def init_callbacks(dash_app, storage, plot_id, engine,theme):
         State('13_fft_phase_fmax_comp', "value"),
         State(plot_id, "children"),
     )
-    def plot_fft_phase_graph(n_clicks,refresh, trigger_record, raw_data_file,partition,run, fmin, fmax, original_state):
+    def plot_fft_phase_graph(n_clicks, plot_style, refresh, trigger_record, raw_data_file, partition, run, fmin, fmax, original_state):
 
         load_figure_template(theme)
         if trigger_record and raw_data_file:

--- a/src/justintime/plots/content/07_fft_phase_plot.py
+++ b/src/justintime/plots/content/07_fft_phase_plot.py
@@ -33,7 +33,7 @@ def init_callbacks(dash_app, storage, plot_id, engine,theme):
         Input("90_plot_button_ctrl", "n_clicks"),
         Input('07_fft_phase_plot', 'style'),
         State('07_refresh_ctrl', "n_clicks"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State('file_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),

--- a/src/justintime/plots/content/13_adc_tp_plot.py
+++ b/src/justintime/plots/content/13_adc_tp_plot.py
@@ -109,6 +109,7 @@ def init_callbacks(dash_app, storage, plot_id, engine, theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('13_adc_tp_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State('trigger_record_select_ctrl', "value"),
         State('file_select_ctrl', "value"),
@@ -125,7 +126,7 @@ def init_callbacks(dash_app, storage, plot_id, engine, theme):
         State("height_select_ctrl","value"),
         State(plot_id, "children"),
     )
-    def plot_trd_graph(n_clicks, refresh,trigger_record, raw_data_file, partition, run, adcmap_selection, colorscale, tr_color_range, static_image, offset, overlay_tps,orientation,height,original_state):
+    def plot_trd_graph(n_clicks, plot_style, refresh, trigger_record, raw_data_file, partition, run, adcmap_selection, colorscale, tr_color_range, static_image, offset, overlay_tps, orientation, height, original_state):
         
         load_figure_template(theme)
         orientation = orientation

--- a/src/justintime/plots/content/13_adc_tp_plot.py
+++ b/src/justintime/plots/content/13_adc_tp_plot.py
@@ -111,7 +111,7 @@ def init_callbacks(dash_app, storage, plot_id, engine, theme):
         Input("90_plot_button_ctrl", "n_clicks"),
         Input('13_adc_tp_plot', 'style'),
         State('07_refresh_ctrl', "value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State('file_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),

--- a/src/justintime/plots/content/14_waveform_vs_tp_plot.py
+++ b/src/justintime/plots/content/14_waveform_vs_tp_plot.py
@@ -35,6 +35,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('14_waveform_vs_tp_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
@@ -46,7 +47,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State('file_select_ctrl', "value"),
         State(plot_id, "children"),
     )
-    def plot_fft_graph(n_clicks,refresh, trigger_record,partition,run,plane,channel_num,offset,overlay_tps,raw_data_file,original_state):
+    def plot_fft_graph(n_clicks, plot_style, refresh, trigger_record, partition, run, plane, channel_num, offset, overlay_tps, raw_data_file, original_state):
     
         load_figure_template(theme)
         

--- a/src/justintime/plots/content/14_waveform_vs_tp_plot.py
+++ b/src/justintime/plots/content/14_waveform_vs_tp_plot.py
@@ -37,7 +37,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         Input("90_plot_button_ctrl", "n_clicks"),
         Input('14_waveform_vs_tp_plot', 'style'),
         State('07_refresh_ctrl', "value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
         State("adc_map_selection_ctrl", "value"),

--- a/src/justintime/plots/content/15_fft_per_channel_plot.py
+++ b/src/justintime/plots/content/15_fft_per_channel_plot.py
@@ -34,7 +34,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         Input("90_plot_button_ctrl", "n_clicks"),
         Input('15_fft_per_channel_plot', 'style'),
         State('07_refresh_ctrl', "value"),
-        State('trigger_record_select_ctrl', "value"),
+        Input('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
         State("run_select_ctrl","value"),
         State("adc_map_selection_ctrl", "value"),

--- a/src/justintime/plots/content/15_fft_per_channel_plot.py
+++ b/src/justintime/plots/content/15_fft_per_channel_plot.py
@@ -32,6 +32,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
     @dash_app.callback(
         Output(plot_id, "children"),
         Input("90_plot_button_ctrl", "n_clicks"),
+        Input('15_fft_per_channel_plot', 'style'),
         State('07_refresh_ctrl', "value"),
         State('trigger_record_select_ctrl', "value"),
         State("partition_select_ctrl","value"),
@@ -41,7 +42,7 @@ def init_callbacks(dash_app, storage, plot_id,theme):
         State('file_select_ctrl', "value"),
         State(plot_id, "children"),
     )
-    def plot_fft_graph(n_clicks, refresh,trigger_record,partition,run,plane,channel_num,raw_data_file, original_state):
+    def plot_fft_graph(n_clicks, plot_style, refresh, trigger_record, partition, run, plane, channel_num, raw_data_file, original_state):
     
         load_figure_template(theme)
 


### PR DESCRIPTION
This PR introduces a handful of changes which allow the monitoring pages to refresh with new data files and update plots at a set interval of time, currently 30 seconds. Upon loading the monitoring page, the dropdown menus will automatically populate with initial values based on the most recently available raw data file in the specified data directory. All plots are set to draw using the latest data file when 
1. the page first loads, 
2. the user selects a new trigger record in the dropdown, or
3. the page reloads, whether through a) a user click or b) the new auto refresh button. 

If the "Auto Refresh" checklist item is checked, the page will automatically reload every <interval> seconds, which includes defaulting to the latest available data file and trigger record. If the user changes to an older trigger record and then switches to a new page while "Auto Refresh" is selected, the older trigger record value will persist until the automatic refresh is triggered. If the box is unchecked, the user can freely select dropdown values without worrying about losing them to the next refresh. 