### PR TITLE
Fixes to make it work with develop

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,12 +22,27 @@ cd ..
 ```
 
 ### Running Just-in-Time
-To run `justintime`, you need a directory containing HDF5-format DUNE DAQ data files and you need to select a channel map. As of March 2024, the available channel map options are 'VDColdbox', 'ProtoDUNESP1', 'PD2HD', 'VST', 'FiftyL', and 'ICEBERG'. 
+To run `justintime`, you need a directory containing HDF5-format DUNE DAQ data files and a TPC channel map name. The channel map is passed with the `--tpc-channel-map` flag:
 ```
-python -m justintime.app <DATA FOLDER PATH> <CHANNEL_MAP_NAME>
+python -m justintime.app --tpc-channel-map <CHANNEL_MAP_NAME> <DATA_FOLDER_PATH>
 ```
-By default, this will run `justintime` on port number 8001. You can then navigate to `localhost:8001` in web browser to view the monitoring page. If running `justintime` on a remote host and you want to open the brower on your local machine, you must first set up an ssh tunnel via
+For example, for ProtoDUNE-HD:
+```
+python -m justintime.app --tpc-channel-map PD2HDTPC /path/to/data
+```
+Known working channel map names (passed without the trailing `ChannelMap` suffix, which is appended automatically): `PD2HDTPC`, `PD2VDTPC`. Run `python -m justintime.app --help` for the full list of options.
+
+Additional options:
+| Option | Default | Description |
+|---|---|---|
+| `--tpc-channel-map` | *(required)* | TPC channel map name |
+| `--pds-channel-map` | `SimplePDS` | PDS channel map name |
+| `-p` / `--port` | `8001` | Port to serve on |
+| `--template` | `flatly` | UI theme: `flatly` (light) or `darkly` (dark) |
+| `-v` / `--verbose` | off | Enable debug logging |
+
+By default, this will run `justintime` on port 8001. Navigate to `localhost:8001` in a web browser to view the monitoring page. If running `justintime` on a remote host and you want to open the browser on your local machine, you must first set up an ssh tunnel via
 ```bash
 ssh -KL 8001:<hostname>:8001 <username>@<hostname> -N
 ```
-where `hostname` and `username` are the names of the host machine on which `justintime` is running and the user running it. If you're not sure, run `hostname` and `whoami` in a terminal on the remote host. 
+where `hostname` and `username` are the names of the host machine on which `justintime` is running and the user running it. If you're not sure, run `hostname` and `whoami` in a terminal on the remote host.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+justintime = ["assets/*"]
+
 [project.optional-dependencies]
 dev = [
     "ruff",

--- a/src/justintime/app.py
+++ b/src/justintime/app.py
@@ -3,6 +3,7 @@ from dash.dependencies import Input, Output, State
 import dash_bootstrap_components as dbc
 import click
 import rich
+import os
 
 import logging
 from rich.logging import RichHandler
@@ -41,7 +42,8 @@ def main(verbose: bool, raw_data_path: str, port: int,
 
     theme=([dbc.themes.FLATLY if template=='flatly' else dbc.themes.DARKLY])
     rich.print("Light mode" if theme==[dbc.themes.FLATLY] else "Dark mode")
-    dash_app = Dash(__name__,external_stylesheets=theme)
+    assets_folder = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'assets')
+    dash_app = Dash(__name__, external_stylesheets=theme, assets_folder=assets_folder)
 
     init_dashboard(dash_app, raw_data_path, tpc_channel_map, pds_channel_map, template)
     debug=True

--- a/src/justintime/controls/content/04_partition_run_select_ctrl.py
+++ b/src/justintime/controls/content/04_partition_run_select_ctrl.py
@@ -50,7 +50,7 @@ def init_callbacks(dash_app, engine):
     def update_file_list(data):
         logging.debug('Update_partition called')
         if not data:
-            return {}
+            return ([], None)
         opts = list(data.keys())
         return (opts, None)
 


### PR DESCRIPTION
# Description

Fixing justintime to work with recent nightlies (that includes updating Dash to 4 causing problems). 

Changes:
- **Callback type error** (`04_partition_run_select_ctrl.py`): Returns `([], None)` instead of `{}`. 
- **Assets missing in package** (`pyproject.toml`): Added package-data to ensure the assets/ folder is included during installation.
- **Assets not found at runtime** (`app.py`): Explicitly passed assets_folder using __file__ so Dash 4.x correctly resolves the path when run via python -m.
- **Documentation** (`README.md`): Updated CLI syntax to reflect that --tpc-channel-map is a required flag, added current channel map examples (PD2HDTPC/PD2VDTPC), and documented all options.

To test:
install and run local version (compare pre and post).

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [X] Unit tests pass (e.g. `dbt-build --unittest`)
- [X] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [X] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

None of the tests are using justintime.
Pre-commit is not available for this package. 

There were few problems reported of type:
```
🚨 Problem(s) found in logfile /tmp/pytest-of-mrigan/pytest-20/run4/log_mrigan_SSH_SHELL_process_manager.txt:
[2026/05/27 11:53:56 UTC] WARNING    ssh_process_lifetime_manager_shell.py:10 drunc.drunc.processes.ssh_process_lifetime_manager Failed to retrieve metadata for process 6f65cdc8-aa17-4066-a92f-f747f7978e5a. Remote process monitoring will not be started.

[2026/05/27 11:55:04 UTC] WARNING    ssh_process_lifetime_manager_shell.py:13 drunc.drunc.processes.ssh_process_lifetime_manager No remote PID for 6f65cdc8-aa17-4066-a92f-f747f7978e5a, terminating SSH client. Cannot guarantee remote process termination.
```
which I believe have nothing to do with this change. 

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.

Was not able to use lint for python package:
```
Package to lint is justintime
Unable to find sourcecode/justintime; exiting...
ERROR: [Wed May 27 14:03:46 CEST 2026] [/cvmfs/dunedaq.opensciencegrid.org/tools/dbt/v8.13.1/bin/dbt-build:651]: There was a problem linting package "justintime". Exiting...
```